### PR TITLE
[bitnami/moodle] Handle --prefix (table prefix) being overridden via MOODLE_INSTALL_EX…

### DIFF
--- a/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -156,6 +156,23 @@ moodle_initialize() {
         read -r -a extra_args <<<"$MOODLE_INSTALL_EXTRA_ARGS"
         [[ "${#extra_args[@]}" -gt 0 ]] && moodle_install_args+=("${extra_args[@]}")
 
+        # Handle --prefix (table prefix) being overridden via MOODLE_INSTALL_EXTRA_ARGS
+        mdl_prefix="mdl_"
+        for extra_arg in "${extra_args[@]}"; do
+            if [[ $extra_arg == --prefix=* ]]; then
+                parts=$( echo $extra_arg | tr "=" "\n" )
+                declare -i i=1
+                for part in $parts ; do
+                    if [[ $i -eq 2 ]] ; then
+                        mdl_prefix=$part
+                    else
+                        mdl_prefix=""
+                    fi
+                    i+=1
+                done
+            fi
+        done
+        
         # Setup Moodle
         if ! is_boolean_yes "$MOODLE_SKIP_BOOTSTRAP"; then
             info "Running Moodle install script"


### PR DESCRIPTION
…TRA_ARGS

At the moment libmoodle.sh assumes a table prefix of the default mdl_ .  When someone overrides this with the --prefix=xxx, then there are errors with the sql statements in libmoodle.sh that reference tables with mdl_....

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
Allow users to specify the --prefix via MOODLE_INSTALL_EXTRA_ARGS.  This helps when migrating from an existing install to a container.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
